### PR TITLE
Implement fortius support based on github FortAnt project technology.

### DIFF
--- a/src/Train/Fortius.h
+++ b/src/Train/Fortius.h
@@ -93,27 +93,27 @@ public:
     int quit(int error);                        // called by thread before exiting
 
     bool find();                                // either unconfigured or configured device found
-    bool discover(QString deviceFilename);        // confirm CT is attached to device
+    bool discover(QString deviceFilename);      // confirm CT is attached to device
 
     // SET
     void setLoad(double load);                  // set the load to generate in ERGOMODE
-    void setGradient(double gradient);          // set the load to generate in SSMODE
-    void setBrakeCalibrationFactor(double calibrationFactor);     // Impacts relationship between brake setpoint and load
-    void setPowerScaleFactor(double calibrationFactor);         // Scales output power, so user can adjust to match hub or crank power meter
+    void setSimState(double resistanceNewtons, double speedKph, double gradient); // set the load to generate in SSMODE
+    void setBrakeCalibrationFactor(double calibrationFactor); // Impacts relationship between brake setpoint and load
+    void setPowerScaleFactor(double calibrationFactor);       // Scales output power, so user can adjust to match hub or crank power meter
     void setMode(int mode);
     void setWeight(double weight);                 // set the total weight of rider + bike in kg's
-    
-    int getMode();
-    double getGradient();
-    double getLoad();
-    double getBrakeCalibrationFactor();
-    double getPowerScaleFactor();
-    double getWeight();
-    
+
+    int    getMode() const;
+    double getGradient() const;
+    double getLoad() const;
+    double getBrakeCalibrationFactor() const;
+    double getPowerScaleFactor() const;
+    double getWeight() const;
+
     // GET TELEMETRY AND STATUS
     // direct access to class variables is not allowed because we need to use wait conditions
     // to sync data read/writes between the run() thread and the main gui thread
-    void getTelemetry(double &power, double &heartrate, double &cadence, double &speed, double &distance, int &buttons, int &steering, int &status);
+    void getTelemetry(double &powerWatts, double &heartrate, double &cadence, double &speedKph, double &distance, int &buttons, int &steering, int &status);
 
 private:
     void run();                                 // called by start to kick off the CT comtrol thread
@@ -135,26 +135,29 @@ private:
     //void unpackTelemetry(int &b1, int &b2, int &b3, int &buttons, int &type, int &value8, int &value12);
 
     // Mutex for controlling accessing private data
-    QMutex pvars;
+    mutable QMutex pvars;
 
-    // INBOUND TELEMETRY - all volatile since it is updated by the run() thread
-    volatile double devicePower;            // current output power in Watts
-    volatile double deviceHeartRate;        // current heartrate in BPM
-    volatile double deviceCadence;          // current cadence in RPM
-    volatile double deviceSpeed;            // current speed in KPH
-    volatile double deviceDistance;         // odometer in meters
-    volatile int    deviceButtons;          // Button status
-    volatile int    deviceStatus;           // Device status running, paused, disconnected
-    volatile int    deviceSteering;            // Steering angle
+    // INBOUND TELEMETRY - read & write requires lock since written by run() thread
+    double devicePowerWatts;       // current output power in Watts
+    double deviceHeartRate;        // current heartrate in BPM
+    double deviceCadence;          // current cadence in RPM
+    double deviceSpeedMS;          // current speed in Meters per second (derived from wheel speed)
+    double deviceWheelSpeed;       // current wheel speed from device
+    double deviceDistance;         // odometer in meters
+    int    deviceButtons;          // Button status
+    int    deviceStatus;           // Device status running, paused, disconnected
+    int    deviceSteering;         // Steering angle
     
-    // OUTBOUND COMMANDS - all volatile since it is updated by the GUI thread
-    volatile int mode;
-    volatile double load;
-    volatile double gradient;
-    volatile double brakeCalibrationFactor;
-    volatile double powerScaleFactor;
-    volatile double weight;
-    
+    // OUTBOUND COMMANDS read & write requires lock since written by gui() thread
+    int    mode;
+    double loadWatts;
+    double resistanceNewtons;      // load demanded by simulator
+    double simSpeedMS;             // simulator's speed, a speed to match if possible
+    double gradient;               // not used
+    double brakeCalibrationFactor;
+    double powerScaleFactor;
+    double weight;
+
     // i/o message holder
     uint8_t buf[64];
 
@@ -163,7 +166,7 @@ private:
 
     // raw device utils
     int rawWrite(uint8_t *bytes, int size); // unix!!
-    int rawRead(uint8_t *bytes, int size); // unix!!
+    int rawRead(uint8_t *bytes, int size);  // unix!!
 };
 
 #endif // _GC_Fortius_h

--- a/src/Train/FortiusController.cpp
+++ b/src/Train/FortiusController.cpp
@@ -139,9 +139,9 @@ FortiusController::setLoad(double load)
 }
 
 void
-FortiusController::setGradient(double grade)
+FortiusController::setSimState(double resistanceNewtons, double speedKph, double gradient)
 {
-    myFortius->setGradient(grade);
+    myFortius->setSimState(resistanceNewtons, speedKph, gradient);
 }
 
 void

--- a/src/Train/FortiusController.h
+++ b/src/Train/FortiusController.h
@@ -48,7 +48,7 @@ public:
     void getRealtimeData(RealtimeData &rtData);
     void pushRealtimeData(RealtimeData &rtData);
     void setLoad(double);
-    void setGradient(double);
+    void setSimState(double, double, double) override;
     void setMode(int);
     void setWeight(double);
 };

--- a/src/Train/RealtimeController.h
+++ b/src/Train/RealtimeController.h
@@ -102,7 +102,12 @@ public:
 
     // only relevant for Computrainer like devices
     virtual void setLoad(double) { return; }
+private:
+    // This function exists to be overridden by existing drivers, but should
+    // not be called by simulation loop.
     virtual void setGradient(double) { return; }
+public:
+    virtual void setSimState(double, double, double gradient) { setGradient(gradient); }
     virtual void setMode(int) { return; }
     virtual void setWindSpeed(double) { return; }
     virtual void setWeight(double) { return; }

--- a/src/Train/RealtimeData.cpp
+++ b/src/Train/RealtimeData.cpp
@@ -25,7 +25,7 @@ RealtimeData::RealtimeData()
 {
     name[0] = '\0';
     hr= watts= altWatts= speed= wheelRpm= load= slope= torque= 0.0;
-    cadence = distance = altDistance = virtualSpeed = wbal = 0.0;
+    cadence = distance = altDistance = virtualSpeed = wbal = resistanceNewtons = 0.0;
     lap = msecs = lapMsecs = lapMsecsRemaining = ergMsecsRemaining = 0;
     thb = smo2 = o2hb = hhb = 0.0;
     lrbalance = rte = lte = lps = rps = 0.0;
@@ -77,6 +77,10 @@ void RealtimeData::setWbal(double wbal)
 void RealtimeData::setVirtualSpeed(double speed)
 {
     this->virtualSpeed = speed;
+}
+void RealtimeData::setResistanceNewtons(double x)
+{
+    this->resistanceNewtons = x;
 }
 void RealtimeData::setWheelRpm(double wheelRpm, bool fMarkWheelRpmTime)
 {
@@ -199,6 +203,10 @@ double RealtimeData::getWbal() const
 double RealtimeData::getVirtualSpeed() const
 {
     return virtualSpeed;
+}
+double RealtimeData::getResistanceNewtons() const
+{
+    return resistanceNewtons;
 }
 double RealtimeData::getWheelRpm() const
 {
@@ -379,6 +387,9 @@ double RealtimeData::value(DataSeries series) const
     case VirtualSpeed: return virtualSpeed;
         break;
 
+    case ResistanceNewtons: return resistanceNewtons;
+        break;
+
     case Cadence: return cadence;
         break;
 
@@ -504,6 +515,7 @@ const QList<RealtimeData::DataSeries> &RealtimeData::listDataSeries()
         seriesList << AvgCadenceLap;
         seriesList << AvgHeartRateLap;
         seriesList << VirtualSpeed;
+        seriesList << ResistanceNewtons;
         seriesList << AltWatts;
         seriesList << LRBalance;
         seriesList << LapTimeRemaining;
@@ -596,6 +608,9 @@ QString RealtimeData::seriesName(DataSeries series)
         break;
 
     case VirtualSpeed: return tr("Virtual Speed");
+        break;
+
+    case ResistanceNewtons: return tr("Resistance Newtons");
         break;
 
     case Cadence: return tr("Cadence");

--- a/src/Train/RealtimeData.h
+++ b/src/Train/RealtimeData.h
@@ -42,7 +42,7 @@ public:
                       Rf, RMV, VO2, VCO2, RER, TidalVolume, FeO2,
                       AvgWatts, AvgSpeed, AvgCadence, AvgHeartRate,
                       AvgWattsLap, AvgSpeedLap, AvgCadenceLap, AvgHeartRateLap,
-                      VirtualSpeed, AltWatts, LRBalance, LapTimeRemaining,
+                      VirtualSpeed, ResistanceNewtons, AltWatts, LRBalance, LapTimeRemaining,
                       LeftTorqueEffectiveness, RightTorqueEffectiveness,
                       LeftPedalSmoothness, RightPedalSmoothness, Slope, 
                       LapDistance, LapDistanceRemaining, ErgTimeRemaining,
@@ -67,6 +67,7 @@ public:
     void setSpeed(double speed);
     void setWbal(double speed);
     void setVirtualSpeed(double speed);
+    void setResistanceNewtons(double newtons);
     void setWheelRpm(double wheelRpm, bool fMarkTimeSample = false);
     void setCadence(double aCadence);
     void setLoad(double load);
@@ -125,6 +126,7 @@ public:
     double getSpeed() const;
     double getWbal() const;
     double getVirtualSpeed() const;
+    double getResistanceNewtons() const;
     double getWheelRpm() const;
     std::chrono::high_resolution_clock::time_point getWheelRpmSampleTime() const;
     double getCadence() const;
@@ -184,6 +186,7 @@ private:
     double lapDistance;
     double lapDistanceRemaining;
     double virtualSpeed;
+    double resistanceNewtons;
     double wbal;
     double hhb, o2hb;
     double rer;

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -349,7 +349,7 @@ TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(contex
     wbalr = wbal = 0;
     load_msecs = total_msecs = lap_msecs = 0;
     displayWorkoutDistance = displayDistance = displayPower = displayHeartRate =
-    displaySpeed = displayCadence = slope = load = 0;
+    displaySpeed = displayCadence = slope = resistanceNewtons = load = 0;
     displaySMO2 = displayTHB = displayO2HB = displayHHB = 0;
     displayLRBalance = displayLTE = displayRTE = displayLPS = displayRPS = 0;
     displayLatitude = displayLongitude = displayAltitude = 0.0;
@@ -1126,7 +1126,7 @@ void TrainSidebar::Start()       // when start button is pressed
         //gui_timer->start(REFRESHRATE);
         if (status & RT_RECORDING) disk_timer->start(SAMPLERATE);
         load_period.restart();
-        if (status & RT_WORKOUT) load_timer->start(LOADRATE);
+        load_timer->start(LOADRATE);
 
 #if !defined GC_VIDEO_NONE
         mediaTree->setEnabled(false);
@@ -1151,7 +1151,7 @@ void TrainSidebar::Start()       // when start button is pressed
         //foreach(int dev, activeDevices) Devices[dev].controller->pause();
         //gui_timer->stop();
         if (status & RT_RECORDING) disk_timer->stop();
-        if (status & RT_WORKOUT) load_timer->stop();
+        load_timer->stop();
         load_msecs += load_period.restart();
 
 #if !defined GC_VIDEO_NONE
@@ -1190,6 +1190,7 @@ void TrainSidebar::Start()       // when start button is pressed
         // START!
         load = 100;
         slope = 0.0;
+        resistanceNewtons = 0.0;
 
         // Reset Speed Simulation
         bicycle.clear();
@@ -1237,9 +1238,7 @@ void TrainSidebar::Start()       // when start button is pressed
         //    Devices[dev].controller->resetCalibrationState();
         //}
 
-        if (status & RT_WORKOUT) {
-            load_timer->start(LOADRATE);      // start recording
-        }
+        load_timer->start(LOADRATE);      // start recording
 
         if (recordSelector->isChecked()) {
             setStatusFlags(RT_RECORDING);
@@ -1293,7 +1292,7 @@ void TrainSidebar::Pause()        // pause capture to recalibrate
         gui_timer->start(REFRESHRATE);
         if (status & RT_RECORDING) disk_timer->start(SAMPLERATE);
         load_period.restart();
-        if (status & RT_WORKOUT) load_timer->start(LOADRATE);
+        load_timer->start(LOADRATE);
 
 #if !defined GC_VIDEO_NONE
         mediaTree->setEnabled(false);
@@ -1312,7 +1311,7 @@ void TrainSidebar::Pause()        // pause capture to recalibrate
         setStatusFlags(RT_PAUSED);
         gui_timer->stop();
         if (status & RT_RECORDING) disk_timer->stop();
-        if (status & RT_WORKOUT) load_timer->stop();
+        load_timer->stop();
         load_msecs += load_period.restart();
 
         // enable media tree so we can change movie
@@ -1364,6 +1363,7 @@ void TrainSidebar::Stop(int deviceStatus)        // when stop button is pressed
 
     load = 0;
     slope = 0.0;
+    resistanceNewtons = 0.0;
 
     QDateTime now = QDateTime::currentDateTime();
 
@@ -1409,10 +1409,8 @@ void TrainSidebar::Stop(int deviceStatus)        // when stop button is pressed
         status &= ~RT_RECORDING;
     }
 
-    if (status & RT_WORKOUT) {
-        load_timer->stop();
-        load_msecs = 0;
-    }
+    load_timer->stop();
+    load_msecs = 0;
 
     // get back to normal after it may have been adusted by the user
     //lastAppliedIntensity=100;
@@ -1898,6 +1896,15 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
 
             rtData.setVirtualSpeed(vs);
 
+            // Compute resisting watts needed for current slope and speed. This can be used to
+            // drive resistance of trainers that only support ergo mode.
+            double speedMS = displaySpeed / 3.6;
+            double resistanceWatts = (status & RT_MODE_SLOPE)
+                ? bicycle.WattsForV(BicycleSimState(rtData), speedMS)
+                : displayPower;
+            resistanceNewtons = speedMS > 0. ? resistanceWatts / speedMS : 0;
+            rtData.setResistanceNewtons(resistanceNewtons);
+
             // W'bal on the fly
             // using Dave Waterworth's reformulation
             double TAU = appsettings->cvalue(context->athlete->cyclist, GC_WBALTAU, 300).toInt();
@@ -1914,19 +1921,6 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
 
             // go update the displays...
             context->notifyTelemetryUpdate(rtData); // signal everyone to update telemetry
-
-            // set now to current time when not using a workout
-            // but limit to almost every second (account for
-            // slight timing errors of 100ms or so)
-
-            // Do some rounding to the hundreds because as time goes by, rtData.getMsecs() drifts just below and then it does not pass the mod 1000 < 100 test
-            // For example:  msecs = 42199.  Mod 1000 = 199 versus msecs = 42000.  Mod 1000 = 0
-            // With this, it will now call tick just about every second
-            long rmsecs = round((rtData.getMsecs() + 99) / 100) * 100;
-            // Test for <= 100ms
-            if (!(status&RT_WORKOUT) && ((rmsecs % 1000) <= 100)) {
-                context->notifySetNow(rtData.getMsecs());
-            }
         }
 
 #ifdef Q_OS_MAC
@@ -2084,14 +2078,16 @@ void TrainSidebar::loadUpdate()
     load_msecs += load_period.restart();
 
     if (status&RT_MODE_ERGO) {
-        load = ergFileQueryAdapter.wattsAt(load_msecs, curLap);
+        if (context->currentErgFile()) {
+            load = ergFileQueryAdapter.wattsAt(load_msecs, curLap);
 
-        if(displayWorkoutLap != curLap)
-        {
-            context->notifyNewLap();
-            maintainLapDistanceState();
+            if (displayWorkoutLap != curLap)
+            {
+                context->notifyNewLap();
+                maintainLapDistanceState();
+            }
+            displayWorkoutLap = curLap;
         }
-        displayWorkoutLap = curLap;
 
         // we got to the end!
         if (load == -100) {
@@ -2102,21 +2098,23 @@ void TrainSidebar::loadUpdate()
         }
     } else {
 
-        // Call gradientAt to obtain current lap num.
-        ergFileQueryAdapter.gradientAt(displayWorkoutDistance * 1000., curLap);
-        
-        if(displayWorkoutLap != curLap) {
-            context->notifyNewLap();
-            maintainLapDistanceState();            
-        }
+        if (context->currentErgFile()) {
+            // Call gradientAt to obtain current lap num.
+            ergFileQueryAdapter.gradientAt(displayWorkoutDistance * 1000., curLap);
 
-        displayWorkoutLap = curLap;
+            if (displayWorkoutLap != curLap) {
+                context->notifyNewLap();
+                maintainLapDistanceState();
+            }
+
+            displayWorkoutLap = curLap;
+        }
 
         // we got to the end!
         if (slope == -100) {
             Stop(DEVICE_OK);
         } else {
-            foreach(int dev, activeDevices) Devices[dev].controller->setGradient(slope);
+            foreach(int dev, activeDevices) Devices[dev].controller->setSimState(resistanceNewtons, displaySpeed, slope);
             context->notifySetNow(displayWorkoutDistance * 1000);
         }
     }
@@ -2143,7 +2141,7 @@ void TrainSidebar::toggleCalibration()
         load_period.restart();
 
         clearStatusFlags(RT_CALIBRATING);
-        if (status & RT_WORKOUT) load_timer->start(LOADRATE);
+        load_timer->start(LOADRATE);
         if (status & RT_RECORDING) disk_timer->start(SAMPLERATE);
         context->notifyUnPause(); // get video started again, amongst other things
 
@@ -2163,7 +2161,7 @@ void TrainSidebar::toggleCalibration()
                 if (calibrationDeviceIndex == dev) {
                     Devices[dev].controller->setCalibrationState(CALIBRATION_STATE_IDLE);
                     Devices[dev].controller->setMode(RT_MODE_SPIN);
-                    Devices[dev].controller->setGradient(slope);
+                    Devices[dev].controller->setSimState(resistanceNewtons, displaySpeed, slope);
                 }
             }
         }
@@ -2177,7 +2175,7 @@ void TrainSidebar::toggleCalibration()
 
         setStatusFlags(RT_CALIBRATING);
         if (status & RT_RECORDING) disk_timer->stop();
-        if (status & RT_WORKOUT) load_timer->stop();
+        load_timer->stop();
         load_msecs += load_period.restart();
 
         context->notifyPause(); // get video started again, amongst other things
@@ -2193,7 +2191,7 @@ void TrainSidebar::toggleCalibration()
                 if (status&RT_MODE_ERGO)
                     Devices[dev].controller->setLoad(0);
                 else
-                    Devices[dev].controller->setGradient(0);
+                    Devices[dev].controller->setSimState(0, 0, 0);
 
 
                 Devices[dev].controller->setMode(RT_MODE_CALIBRATE);
@@ -2577,7 +2575,7 @@ void TrainSidebar::Higher()
         if (status&RT_MODE_ERGO)
             foreach(int dev, activeDevices) Devices[dev].controller->setLoad(load);
         else
-            foreach(int dev, activeDevices) Devices[dev].controller->setGradient(slope);
+            foreach(int dev, activeDevices) Devices[dev].controller->setSimState(resistanceNewtons, displaySpeed, slope);
     }
 
     emit setNotification(tr("Increasing intensity.."), 2);
@@ -2603,7 +2601,7 @@ void TrainSidebar::Lower()
         if (status&RT_MODE_ERGO)
             foreach(int dev, activeDevices) Devices[dev].controller->setLoad(load);
         else
-            foreach(int dev, activeDevices) Devices[dev].controller->setGradient(slope);
+            foreach(int dev, activeDevices) Devices[dev].controller->setSimState(resistanceNewtons, displaySpeed, slope);
     }
 
     emit setNotification(tr("Decreasing intensity.."), 2);

--- a/src/Train/TrainSidebar.h
+++ b/src/Train/TrainSidebar.h
@@ -265,6 +265,7 @@ class TrainSidebar : public GcWindow
         double displayLatitude, displayLongitude, displayAltitude; // geolocation
         long load;
         double slope;
+        double resistanceNewtons;  // newtons of resistance for gradient mode.
         int displayWorkoutLap;     // which Lap in the workout are we at?
         bool lapAudioEnabled;
         bool lapAudioThisLap;


### PR DESCRIPTION
Device brake force for sim mode is now set directly via new
setSimState api on deviceController, which allows for simulations
force to be set directly on trainer, instead of each trainer
implementing their own gradient simulation.

Devices that dont implement setSimSate are called with setGradient
as before.

Remove special case for non-workout modes, they are now handled
via loadUpdate and timer, same as workout modes. This is necessary
to send force updates when no workout is present.

This change does not implement:
- setSimState for other trainers that could benefit from it.
- calibration for fortius
- virtual and device speed synchronization for fortius.

Huge thanks to Mattipee and MickyDuck for reviews, testing and
feedback.